### PR TITLE
Fix unterminated alias in `git/gitconfig-osx`

### DIFF
--- a/git/gitconfig-osx
+++ b/git/gitconfig-osx
@@ -14,7 +14,7 @@
   # @usage
   #   git root
   #
-  root = "!_() { !pwd -P }"
+  root = "!_() { !pwd -P; }"
 
   #
   # Diffs the changes git stash would apply.


### PR DESCRIPTION
As evidenced by its broken syntax highlighting, `gitconfig-osx` contains an unterminated shell command in [one of its aliases](https://github.com/chauncey-garrett/dotfiles/blob/727f8f9361a2e0d5e84ea4460b07f6ac809b73f3/git/gitconfig-osx#L17):

https://github.com/chauncey-garrett/dotfiles/blob/727f8f9361a2e0d5e84ea4460b07f6ac809b73f3/git/gitconfig-osx#L12-L22

This PR simply adds the missing semicolon needed to terminate the call to `pwd(1)`:

~~~gitconfig
[alias]
	# Change to working directory to the root of the git repo.
	#
	# @usage
	#   git root
	#
	root = "!_() { !pwd -P; }"

	# Renames the provided stash.
	# http://stackoverflow.com/a/25935360/256429
~~~